### PR TITLE
Use HTTPS to resolve dependencies in Maven Build

### DIFF
--- a/ldcbench.parent/pom.xml
+++ b/ldcbench.parent/pom.xml
@@ -34,12 +34,12 @@
     <repository>
       <id>maven.aksw.internal</id>
       <name>University Leipzig, AKSW Maven2 Repository</name>
-      <url>http://maven.aksw.org/repository/internal</url>
+      <url>https://maven.aksw.org/repository/internal</url>
     </repository>
     <repository>
       <id>maven.aksw.snapshots</id>
       <name>University Leipzig, AKSW Maven2 Repository</name>
-      <url>http://maven.aksw.org/repository/snapshots</url>
+      <url>https://maven.aksw.org/repository/snapshots</url>
     </repository>
   </repositories>
 

--- a/ldcbench.sparql-node/pom.xml
+++ b/ldcbench.sparql-node/pom.xml
@@ -18,12 +18,12 @@
 		<repository>
 			<id>maven.aksw.internal</id>
 			<name>AKSW Internal Release Repository</name>
-			<url>http://maven.aksw.org/repository/internal/</url>
+			<url>https://maven.aksw.org/repository/internal/</url>
 		</repository>
 		<repository>
 			<id>maven.aksw.snapshots</id>
 			<name>University Leipzig, AKSW Maven2 Repository</name>
-			<url>http://maven.aksw.org/repository/snapshots</url>
+			<url>https://maven.aksw.org/repository/snapshots</url>
 		</repository>
 		<repository>
 			<id>spring-releases</id>


### PR DESCRIPTION
Resolve dependencies of the AKSW repository over https.